### PR TITLE
Fix null not highlighted correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export const json5Language = LRLanguage.define({
         'PropertyName!': t.propertyName,
         Number: t.number,
         'True False': t.bool,
-        null: t.null,
+        Null: t.null,
         ', PropertyColon': t.separator,
         '[ ]': t.squareBracket,
         '{ }': t.brace,


### PR DESCRIPTION
Compare to: https://github.com/lezer-parser/json/blob/main/src/highlight.js

Would be grateful if you could also bump the version on npm if you merge this 🙏